### PR TITLE
chore: rename to `gnolang/goleveldb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an implementation of the [LevelDB key/value database](https://github.com
 Installation
 -----------
 
-	go get github.com/syndtr/goleveldb/leveldb
+	go get github.com/gnolang/goleveldb/leveldb
 
 Requirements
 -----------
@@ -104,4 +104,4 @@ defer db.Close()
 Documentation
 -----------
 
-You can read package documentation [here](https://pkg.go.dev/github.com/syndtr/goleveldb).
+You can read package documentation [here](https://pkg.go.dev/github.com/gnolang/goleveldb).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/syndtr/goleveldb
+module github.com/gnolang/goleveldb
 
 go 1.14
 

--- a/leveldb/batch.go
+++ b/leveldb/batch.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/memdb"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 // ErrBatchCorrupted records reason of batch corruption. This error will be

--- a/leveldb/batch_test.go
+++ b/leveldb/batch_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestBatchHeader(t *testing.T) {

--- a/leveldb/bench_test.go
+++ b/leveldb/bench_test.go
@@ -16,9 +16,9 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 func randomString(r *rand.Rand, n int) []byte {

--- a/leveldb/cache/cache.go
+++ b/leveldb/cache/cache.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // Cacher provides interface to implements a caching functionality.

--- a/leveldb/comparer.go
+++ b/leveldb/comparer.go
@@ -7,7 +7,7 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
 )
 
 type iComparer struct {

--- a/leveldb/corrupt_test.go
+++ b/leveldb/corrupt_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 const ctValSize = 1000

--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -17,15 +17,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/cache"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/journal"
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/table"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/cache"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/journal"
+	"github.com/gnolang/goleveldb/leveldb/memdb"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/table"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // DB is a LevelDB database.

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 var (

--- a/leveldb/db_iter.go
+++ b/leveldb/db_iter.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type memdbReleaser struct {

--- a/leveldb/db_snapshot.go
+++ b/leveldb/db_snapshot.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type snapshotElement struct {

--- a/leveldb/db_state.go
+++ b/leveldb/db_state.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/journal"
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/journal"
+	"github.com/gnolang/goleveldb/leveldb/memdb"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 var (

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -25,14 +25,14 @@ import (
 
 	"github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func tkey(i int) []byte {

--- a/leveldb/db_transaction.go
+++ b/leveldb/db_transaction.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 var errTransactionDone = errors.New("leveldb: transaction already closed")

--- a/leveldb/db_util.go
+++ b/leveldb/db_util.go
@@ -7,11 +7,11 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // Reader is the interface that wraps basic Get and NewIterator methods.

--- a/leveldb/db_write.go
+++ b/leveldb/db_write.go
@@ -10,9 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/memdb"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func (db *DB) writeJournal(batches []*Batch, seq uint64, sync bool) error {

--- a/leveldb/errors.go
+++ b/leveldb/errors.go
@@ -7,7 +7,7 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/errors"
 )
 
 // Common errors.

--- a/leveldb/errors/errors.go
+++ b/leveldb/errors/errors.go
@@ -11,8 +11,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // Common errors.

--- a/leveldb/external_test.go
+++ b/leveldb/external_test.go
@@ -10,8 +10,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 var _ = testutil.Defer(func() {

--- a/leveldb/filter.go
+++ b/leveldb/filter.go
@@ -7,7 +7,7 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/filter"
 )
 
 type iFilter struct {

--- a/leveldb/filter/bloom.go
+++ b/leveldb/filter/bloom.go
@@ -7,7 +7,7 @@
 package filter
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func bloomHash(key []byte) uint32 {

--- a/leveldb/filter/bloom_test.go
+++ b/leveldb/filter/bloom_test.go
@@ -8,7 +8,7 @@ package filter
 
 import (
 	"encoding/binary"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 	"testing"
 )
 

--- a/leveldb/iterator/array_iter.go
+++ b/leveldb/iterator/array_iter.go
@@ -7,7 +7,7 @@
 package iterator
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // BasicArray is the interface that wraps basic Len and Search method.

--- a/leveldb/iterator/array_iter_test.go
+++ b/leveldb/iterator/array_iter_test.go
@@ -9,8 +9,8 @@ package iterator_test
 import (
 	. "github.com/onsi/ginkgo"
 
-	. "github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	. "github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 var _ = testutil.Defer(func() {

--- a/leveldb/iterator/indexed_iter.go
+++ b/leveldb/iterator/indexed_iter.go
@@ -7,8 +7,8 @@
 package iterator
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // IteratorIndexer is the interface that wraps CommonIterator and basic Get

--- a/leveldb/iterator/indexed_iter_test.go
+++ b/leveldb/iterator/indexed_iter_test.go
@@ -11,9 +11,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	. "github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	. "github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 type keyValue struct {

--- a/leveldb/iterator/iter.go
+++ b/leveldb/iterator/iter.go
@@ -11,7 +11,7 @@ package iterator
 import (
 	"errors"
 
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 var (

--- a/leveldb/iterator/iter_suite_test.go
+++ b/leveldb/iterator/iter_suite_test.go
@@ -3,7 +3,7 @@ package iterator_test
 import (
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestIterator(t *testing.T) {

--- a/leveldb/iterator/merged_iter.go
+++ b/leveldb/iterator/merged_iter.go
@@ -9,9 +9,9 @@ package iterator
 import (
 	"container/heap"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type dir int

--- a/leveldb/iterator/merged_iter_test.go
+++ b/leveldb/iterator/merged_iter_test.go
@@ -12,9 +12,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	. "github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	. "github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 var _ = testutil.Defer(func() {

--- a/leveldb/journal/journal.go
+++ b/leveldb/journal/journal.go
@@ -82,9 +82,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // These constants are part of the wire format and should not be changed.

--- a/leveldb/key.go
+++ b/leveldb/key.go
@@ -10,8 +10,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 // ErrInternalKeyCorrupted records internal key corruption.

--- a/leveldb/key_test.go
+++ b/leveldb/key_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
 )
 
 var defaultIComparer = &iComparer{comparer.DefaultComparer}

--- a/leveldb/leveldb_suite_test.go
+++ b/leveldb/leveldb_suite_test.go
@@ -3,7 +3,7 @@ package leveldb
 import (
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestLevelDB(t *testing.T) {

--- a/leveldb/memdb/bench_test.go
+++ b/leveldb/memdb/bench_test.go
@@ -11,7 +11,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
 )
 
 func BenchmarkPut(b *testing.B) {

--- a/leveldb/memdb/memdb.go
+++ b/leveldb/memdb/memdb.go
@@ -11,10 +11,10 @@ import (
 	"math/rand"
 	"sync"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // Common errors.

--- a/leveldb/memdb/memdb_suite_test.go
+++ b/leveldb/memdb/memdb_suite_test.go
@@ -3,7 +3,7 @@ package memdb
 import (
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestMemDB(t *testing.T) {

--- a/leveldb/memdb/memdb_test.go
+++ b/leveldb/memdb/memdb_test.go
@@ -10,10 +10,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func (p *DB) TestFindLT(key []byte) (rkey, value []byte, err error) {

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -10,9 +10,9 @@ package opt
 import (
 	"math"
 
-	"github.com/syndtr/goleveldb/leveldb/cache"
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/cache"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/filter"
 )
 
 const (

--- a/leveldb/options.go
+++ b/leveldb/options.go
@@ -7,8 +7,8 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/opt"
 )
 
 func dupOptions(o *opt.Options) *opt.Options {

--- a/leveldb/session.go
+++ b/leveldb/session.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"sync"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/journal"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/journal"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 // ErrManifestCorrupted records manifest corruption. This error will be

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -10,9 +10,9 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/memdb"
+	"github.com/gnolang/goleveldb/leveldb/opt"
 )
 
 const (
@@ -44,7 +44,7 @@ func (s *session) flushMemdb(rec *sessionRecord, mdb *memdb.DB, maxLevel int) (i
 	// key-space is strictly incrementing it will not overlaps with
 	// higher level, thus maximum possible level is always picked, while
 	// overlapping deletion marker pushed into lower level.
-	// See: https://github.com/syndtr/goleveldb/issues/127.
+	// See: https://github.com/gnolang/goleveldb/issues/127.
 	flushLevel := s.pickMemdbLevel(t.imin.ukey(), t.imax.ukey(), maxLevel)
 	rec.addTableFile(flushLevel, t)
 

--- a/leveldb/session_record.go
+++ b/leveldb/session_record.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 type byteReader interface {

--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -11,8 +11,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb/journal"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/journal"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 // Logging.

--- a/leveldb/storage.go
+++ b/leveldb/storage.go
@@ -1,7 +1,7 @@
 package leveldb
 
 import (
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 	"sync/atomic"
 )
 

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -12,12 +12,12 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/syndtr/goleveldb/leveldb/cache"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/table"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/cache"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/table"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // tFile holds basic information about a table.

--- a/leveldb/table/block_test.go
+++ b/leveldb/table/block_test.go
@@ -13,10 +13,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type blockTesting struct {

--- a/leveldb/table/reader.go
+++ b/leveldb/table/reader.go
@@ -16,14 +16,14 @@ import (
 
 	"github.com/golang/snappy"
 
-	"github.com/syndtr/goleveldb/leveldb/cache"
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/cache"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 // Reader errors.

--- a/leveldb/table/table_suite_test.go
+++ b/leveldb/table/table_suite_test.go
@@ -3,7 +3,7 @@ package table
 import (
 	"testing"
 
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestTable(t *testing.T) {

--- a/leveldb/table/table_test.go
+++ b/leveldb/table/table_test.go
@@ -12,11 +12,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type tableWrapper struct {

--- a/leveldb/table/writer.go
+++ b/leveldb/table/writer.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/golang/snappy"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func sharedPrefixLen(a, b []byte) int {

--- a/leveldb/table_test.go
+++ b/leveldb/table_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 func TestGetOverlaps(t *testing.T) {

--- a/leveldb/testutil/db.go
+++ b/leveldb/testutil/db.go
@@ -12,9 +12,9 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type DB interface{}

--- a/leveldb/testutil/iter.go
+++ b/leveldb/testutil/iter.go
@@ -12,7 +12,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
 )
 
 type IterAct int

--- a/leveldb/testutil/kv.go
+++ b/leveldb/testutil/kv.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type KeyValueEntry struct {

--- a/leveldb/testutil/kvtest.go
+++ b/leveldb/testutil/kvtest.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 func TestFind(db Find, kv KeyValue) {

--- a/leveldb/testutil/storage.go
+++ b/leveldb/testutil/storage.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 var (

--- a/leveldb/testutil/util.go
+++ b/leveldb/testutil/util.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/onsi/ginkgo/config"
 
-	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/gnolang/goleveldb/leveldb/comparer"
 )
 
 var (

--- a/leveldb/testutil_test.go
+++ b/leveldb/testutil_test.go
@@ -9,10 +9,10 @@ package leveldb
 import (
 	. "github.com/onsi/gomega"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type testingDB struct {

--- a/leveldb/util.go
+++ b/leveldb/util.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 func shorten(str string) string {

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -12,9 +12,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb/iterator"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 type tSet struct {

--- a/leveldb/version_test.go
+++ b/leveldb/version_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/testutil"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/testutil"
 )
 
 type testFileRec struct {

--- a/manualtest/dbstress/key.go
+++ b/manualtest/dbstress/key.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 type ErrIkeyCorrupted struct {

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -20,13 +20,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/errors"
-	"github.com/syndtr/goleveldb/leveldb/filter"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/table"
-	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/gnolang/goleveldb/leveldb"
+	"github.com/gnolang/goleveldb/leveldb/errors"
+	"github.com/gnolang/goleveldb/leveldb/filter"
+	"github.com/gnolang/goleveldb/leveldb/opt"
+	"github.com/gnolang/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/table"
+	"github.com/gnolang/goleveldb/leveldb/util"
 )
 
 var (

--- a/manualtest/filelock/main.go
+++ b/manualtest/filelock/main.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/gnolang/goleveldb/leveldb/storage"
 )
 
 var (


### PR DESCRIPTION
Made this change in order to AVOID a replace statement in the `go.mod` of `gnolang/gno` and its users.

`go build ./...` and `go test ./...` successfully runs after the changes.